### PR TITLE
:rocket: add stm32f303vc GCC port and benchmark result

### DIFF
--- a/Include/Platform/A7M/Chip/STM32F303VC/rmp_platform_stm32f303vc.h
+++ b/Include/Platform/A7M/Chip/STM32F303VC/rmp_platform_stm32f303vc.h
@@ -1,0 +1,136 @@
+/******************************************************************************
+Filename   : rmp_platform_stm32f303vc.h
+Author     : zzx
+Date       : 30/03/2025
+Licence    : The Unlicense; see LICENSE for details.
+Description: The configuration file for STM32F303VC.
+******************************************************************************/
+
+/* Define ********************************************************************/
+/* The HAL library */
+#include "stm32f3xx.h"
+#include "core_cm4.h"
+#include "stm32f3xx_hal.h"
+
+/* Debugging */
+/* Assertion */
+#define RMP_ASSERT_ENABLE           (1U)
+/* Invalid parameter checking */
+#define RMP_CHECK_ENABLE            (1U)
+/* Debug logging */
+#define RMP_DBGLOG_ENABLE           (1U)
+
+/* System */
+/* The maximum number of preemption priorities */
+#define RMP_PREEMPT_PRIO_NUM        (32U)
+/* The maximum number of slices allowed */
+#define RMP_SLICE_MAX               (100000U)
+/* The maximum number of semaphore counts allowed */
+#define RMP_SEM_CNT_MAX             (1000U)
+/* The stack size of the init thread */
+#define RMP_INIT_STACK_SIZE         (256U)
+
+/* GUI */
+#define RMP_GUI_ENABLE              (0U)
+/* Anti-aliasing */
+#define RMP_GUI_ANTIALIAS_ENABLE    (0U)
+/* Widgets */
+#define RMP_GUI_WIDGET_ENABLE       (0U)
+
+/* What is the NVIC priority grouping? */
+#define RMP_A7M_NVIC_GROUPING       RMP_A7M_NVIC_GROUPING_P2S6
+/* What is the Systick value? */
+#define RMP_A7M_SYSTICK_VAL         (7200U)
+/* What is the interrupt masking level? */
+#define RMP_A7M_INT_MASK_LVL        (0xFFU)
+/* What is the FPU type? */
+#define RMP_A7M_COP_FPV4_SP         (1U)
+#define RMP_A7M_COP_FPV5_SP         (0U)
+#define RMP_A7M_COP_FPV5_DP         (0U)
+
+/* Other low-level initialization stuff - clock and serial
+ * STM32F303 APB1<36MHz, APB2<72MHz.
+ * This is the default initialization sequence. If you wish to supply
+ * your own, just redirect this macro to a custom function, or do your
+ * initialization stuff in the initialization hook (RMP_START_HOOK). */
+#define RMP_A7M_LOWLVL_INIT() \
+do \
+{ \
+    RCC_ClkInitTypeDef RCC_ClkInitStruct; \
+    RCC_OscInitTypeDef RCC_OscInitStruct; \
+    UART_HandleTypeDef UART1_Handle; \
+    GPIO_InitTypeDef GPIO_Init; \
+	HAL_Init(); \
+    RMP_Clear(&RCC_ClkInitStruct, sizeof(RCC_ClkInitStruct)); \
+    RMP_Clear(&RCC_OscInitStruct, sizeof(RCC_OscInitStruct)); \
+    RMP_Clear(&UART1_Handle, sizeof(UART_HandleTypeDef)); \
+    RMP_Clear(&GPIO_Init, sizeof(GPIO_InitTypeDef)); \
+    \
+    /* Enable HSE Oscillator and activate PLL with HSE as source */ \
+    RCC_OscInitStruct.OscillatorType=RCC_OSCILLATORTYPE_HSE; \
+    RCC_OscInitStruct.HSEState=RCC_HSE_ON; \
+	RCC_OscInitStruct.HSEPredivValue = RCC_HSE_PREDIV_DIV1; \
+    RCC_OscInitStruct.PLL.PLLState=RCC_PLL_ON; \
+    RCC_OscInitStruct.PLL.PLLSource=RCC_PLLSOURCE_HSE; \
+    RCC_OscInitStruct.PLL.PLLMUL=RCC_PLL_MUL9; \
+    HAL_RCC_OscConfig(&RCC_OscInitStruct); \
+    \
+    /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2 clocks dividers */ \
+    RCC_ClkInitStruct.ClockType=(RCC_CLOCKTYPE_SYSCLK|RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2); \
+    RCC_ClkInitStruct.SYSCLKSource=RCC_SYSCLKSOURCE_PLLCLK; \
+    RCC_ClkInitStruct.AHBCLKDivider=RCC_SYSCLK_DIV1; \
+    RCC_ClkInitStruct.APB1CLKDivider=RCC_HCLK_DIV2; \
+    RCC_ClkInitStruct.APB2CLKDivider=RCC_HCLK_DIV1; \
+    HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2); \
+	__HAL_FLASH_PREFETCH_BUFFER_ENABLE(); \
+    /* Enable USART 1 for user-level operations */ \
+    /* Clock enabling */ \
+    __HAL_RCC_GPIOC_CLK_ENABLE(); \
+    __HAL_RCC_USART1_CLK_ENABLE(); \
+    /* UART IO initialization */ \
+    GPIO_Init.Pin=GPIO_PIN_4; \
+    GPIO_Init.Mode=GPIO_MODE_AF_PP; \
+    GPIO_Init.Pull=GPIO_PULLUP; \
+    GPIO_Init.Speed=GPIO_SPEED_FREQ_HIGH; \
+    GPIO_Init.Alternate=GPIO_AF7_USART1; \
+    HAL_GPIO_Init(GPIOC, &GPIO_Init); \
+    /* UART initialization */ \
+    UART1_Handle.Instance=USART1; \
+    UART1_Handle.Init.BaudRate=115200; \
+    UART1_Handle.Init.WordLength=UART_WORDLENGTH_8B; \
+    UART1_Handle.Init.StopBits=UART_STOPBITS_1; \
+    UART1_Handle.Init.Parity=UART_PARITY_NONE; \
+    UART1_Handle.Init.HwFlowCtl=UART_HWCONTROL_NONE; \
+    UART1_Handle.Init.Mode=UART_MODE_TX; \
+    HAL_UART_Init(&UART1_Handle); \
+    RMP_A7M_PUTCHAR('\r'); \
+    RMP_A7M_PUTCHAR('\n'); \
+    \
+    /* Enable all fault handlers */ \
+    SCB->SHCSR|=RMP_A7M_SHCSR_USGFAULTENA|RMP_A7M_SHCSR_BUSFAULTENA|RMP_A7M_SHCSR_MEMFAULTENA; \
+    \
+    /* Set the priority of timer, svc and faults to the lowest */ \
+    NVIC_SetPriorityGrouping(RMP_A7M_NVIC_GROUPING); \
+    NVIC_SetPriority(SVCall_IRQn, 0xFF); \
+    NVIC_SetPriority(PendSV_IRQn, 0xFF); \
+    NVIC_SetPriority(SysTick_IRQn, 0xFF); \
+    NVIC_SetPriority(BusFault_IRQn, 0xFF); \
+    NVIC_SetPriority(UsageFault_IRQn, 0xFF); \
+    NVIC_SetPriority(DebugMonitor_IRQn, 0xFF); \
+    SysTick_Config(RMP_A7M_SYSTICK_VAL); \
+} \
+while(0)
+
+/* This is for debugging output */
+#define RMP_A7M_PUTCHAR(CHAR) \
+do \
+{ \
+    USART1->TDR=(rmp_ptr_t)(CHAR); \
+    while((USART1->ISR&0x40U)==0U); \
+} \
+while(0)
+/* End Define ****************************************************************/
+
+/* End Of File ***************************************************************/
+
+/* Copyright (C) Evo-Devo Instrum. All rights reserved ***********************/

--- a/Include/Test/Chip/rmp_test_stm32f303vc.h
+++ b/Include/Test/Chip/rmp_test_stm32f303vc.h
@@ -1,0 +1,142 @@
+/******************************************************************************
+Filename    : rmp_test_stm32f405rg.h
+Author      : zzx
+Date        : 30/03/2025
+Licence     : The Unlicense; see LICENSE for details.
+Description : The testbench for STM32F405RG.
+
+GCC 13.2.0 -O3 (SysTick turned on)
+    ___   __  ___ ___
+   / _ \ /  |/  // _ \       Simple real-time kernel
+  / , _// /|_/ // ___/       Standard benchmark test
+ /_/|_|/_/  /_//_/
+====================================================
+Test (number in CPU cycles)        : AVG / MAX / MIN
+Yield                              : 467 / 696 / 460
+Mailbox                            : 1011 / 1236 / 996
+Semaphore                          : 828 / 1048 / 816
+FIFO                               : 508 / 740 / 500
+Message queue                      : 1291 / 1512 / 1272
+Blocking message queue             : 1779 / 1988 / 1752
+Alarm combination (1/2/3/5/7)      : 1835 / 3544 / 1096
+Memory allocation/free pair        : 975 / 1042 / 932
+ISR Mailbox                        : 870 / 1100 / 860
+ISR Semaphore                      : 799 / 1020 / 780
+ISR Message queue                  : 1073 / 1304 / 1060
+ISR Blocking message queue         : 1369 / 1600 / 1352
+******************************************************************************/
+
+/* Include *******************************************************************/
+#include "rmp.h"
+/* End Include ***************************************************************/
+
+/* Define ********************************************************************/
+/* Counter read wrapper */
+#define RMP_CNT_READ()      ((rmp_tim_t)((TIM2->CNT)<<1))
+/* Memory pool test switch */
+#define TEST_MEM_POOL       (8192U)
+/* Minimal build switch */
+/* #define MINIMAL_SIZE */
+/* Timestamp data type */
+typedef rmp_u16_t           rmp_tim_t;
+/* End Define ****************************************************************/
+
+/* Global ********************************************************************/
+#ifndef MINIMAL_SIZE
+rmp_ptr_t Stack_1[256];
+rmp_ptr_t Stack_2[256];
+TIM_HandleTypeDef TIM2_Handle={0};
+TIM_HandleTypeDef TIM4_Handle={0};
+
+void Timer_Init(void);
+void Int_Init(void);
+void Int_Handler(void);
+void Int_Disable(void);
+
+void TIM4_IRQHandler(void);
+/* End Global ****************************************************************/
+
+/* Function:Timer_Init ********************************************************
+Description : Initialize the timer for timing measurements. This function needs
+              to be adapted to your specific hardware.
+Input       : None.
+Output      : None.
+Return      : None.
+******************************************************************************/
+void Timer_Init(void)
+{
+    /* TIM2 clock = CPU clock */
+    TIM2_Handle.Instance=TIM2;
+    TIM2_Handle.Init.Prescaler=0;
+    TIM2_Handle.Init.CounterMode=TIM_COUNTERMODE_UP;
+    TIM2_Handle.Init.Period=(rmp_u16_t)(-1);
+    TIM2_Handle.Init.ClockDivision=TIM_CLOCKDIVISION_DIV1;
+    HAL_TIM_Base_Init(&TIM2_Handle);
+    __HAL_RCC_TIM2_CLK_ENABLE();
+    __HAL_TIM_ENABLE(&TIM2_Handle);
+}
+/* End Function:Timer_Init ***************************************************/
+
+/* Function:Int_Init **********************************************************
+Description : Initialize an periodic interrupt source. This function needs
+              to be adapted to your specific hardware.
+Input       : None.
+Output      : None.
+Return      : None.
+******************************************************************************/
+void Int_Init(void)
+{
+    /* TIM4 clock = CPU clock */
+    TIM4_Handle.Instance=TIM4;
+    TIM4_Handle.Init.Prescaler=0;
+    TIM4_Handle.Init.CounterMode=TIM_COUNTERMODE_UP;
+    TIM4_Handle.Init.Period=7200;
+    TIM4_Handle.Init.ClockDivision=TIM_CLOCKDIVISION_DIV1;
+    TIM4_Handle.Init.RepetitionCounter=0;
+    HAL_TIM_Base_Init(&TIM4_Handle);
+    __HAL_RCC_TIM4_CLK_ENABLE();
+    __HAL_TIM_ENABLE(&TIM4_Handle);
+    /* Clear interrupt pending bit, because we used EGR to update the registers */
+    __HAL_TIM_CLEAR_IT(&TIM4_Handle, TIM_IT_UPDATE);
+    HAL_TIM_Base_Start_IT(&TIM4_Handle);
+}
+
+void HAL_TIM_Base_MspInit(TIM_HandleTypeDef *htim)
+{
+    if(htim->Instance==TIM4)
+    {
+        /* Set the interrupt priority */
+        NVIC_SetPriority(TIM4_IRQn,0xFF);
+        /* Enable timer 4 interrupt */
+        NVIC_EnableIRQ(TIM4_IRQn);
+        /* Enable timer 4 clock */
+        __HAL_RCC_TIM4_CLK_ENABLE();
+    }
+}
+
+/* The interrupt handler */
+void TIM4_IRQHandler(void)
+{
+    TIM4->SR=~TIM_FLAG_UPDATE;
+    Int_Handler();
+}
+/* End Function:Int_Init *****************************************************/
+
+/* Function:Int_Disable *******************************************************
+Description : Disable the periodic interrupt source. This function needs
+              to be adapted to your specific hardware.
+Input       : None.
+Output      : None.
+Return      : None.
+******************************************************************************/
+void Int_Disable(void)
+{
+    /* Disable timer 4 interrupt */
+    NVIC_DisableIRQ(TIM4_IRQn);
+}
+#endif
+/* End Function:Int_Disable **************************************************/
+
+/* End Of File ***************************************************************/
+
+/* Copyright (C) Evo-Devo Instrum. All rights reserved ***********************/

--- a/Project/GCCMF-STM32F303VCT6/makefile
+++ b/Project/GCCMF-STM32F303VCT6/makefile
@@ -1,0 +1,131 @@
+###############################################################################
+#Filename    : RMP
+#Author      : zzx
+#Date        : 26/03/2025
+#Licence     : LGPL v3+; see COPYING for details.
+#Description : Generic Makefile (based on gcc). This file is intended
+#              to be used with STM32F303VC, and the GNU toolchain.
+###############################################################################
+
+# Config ######################################################################
+TARGET=RMP
+CPU=-mcpu=cortex-m4 -mthumb
+CDEFS=-DSTM32F303xC -DUSE_HAL_DRIVER
+
+CFLAGS=-O3 -specs=nano.specs -fsigned-char -fno-common -fno-strict-aliasing -fdata-sections -ffunction-sections -ffreestanding
+AFLAGS=-fdata-sections -ffunction-sections
+WFLAGS=-Wall -Wno-strict-aliasing
+DFLAGS=-g3
+LFLAGS=-specs=nano.specs -specs=nosys.specs -Wl,--gc-sections,--cref
+
+OBJDIR=Object
+PREFIX=arm-none-eabi-
+# End Config ##################################################################
+
+# Source ######################################################################
+INCS+=-I.
+INCS+=-I../../Include
+INCS+=-I../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/CMSIS/Include
+INCS+=-I../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/CMSIS/Device/ST/STM32F3xx/Include
+INCS+=-I../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Inc
+INCS+=-I../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Inc/Conf
+
+CSRCS+=../../Source/Kernel/rmp_kernel.c
+CSRCS+=../../Source/Test/rmp_benchmark.c
+CSRCS+=../../Source/Platform/A7M/rmp_platform_a7m.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/system_stm32f3xx.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_tim.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_tim_ex.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_rcc.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_rcc_ex.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_gpio.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_uart.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_dma.c
+CSRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_cortex.c
+
+ASRCS+=../../Source/Platform/A7M/rmp_platform_a7m_gcc.s
+ASRCS+=../../../M0A00_Library/STM32Cube_FW_F3_V1.11.5/Drivers/CMSIS/Device/ST/STM32F3xx/Source/Templates/gcc/startup_stm32f303xc.s
+
+LDSCRIPT=rmp_platform_stm32f303vc.ld
+LIBS=-lc -lnosys
+# End Source ##################################################################
+
+# Toolchain ###################################################################
+ifdef GCC
+CC=$(GCC)/$(PREFIX)gcc
+AS=$(GCC)/$(PREFIX)gcc -x assembler-with-cpp
+CP=$(GCC)/$(PREFIX)objcopy
+LD=$(GCC)/$(PREFIX)gcc
+SZ=$(GCC)/$(PREFIX)size
+else
+CC=$(PREFIX)gcc
+AS=$(PREFIX)gcc -x assembler-with-cpp
+CP=$(PREFIX)objcopy
+LD=$(PREFIX)gcc
+SZ=$(PREFIX)size
+endif
+
+HEX=$(CP) -O ihex
+BIN=$(CP) -O binary -S
+# End Toolchain ###############################################################
+
+# User ########################################################################
+-include user
+# End User ####################################################################
+
+# Build #######################################################################
+COBJS=$(CSRCS:%.c=%.o)
+CDEPS=$(CSRCS:%.c=%.d)
+AOBJS=$(ASRCS:%.s=%.o)
+ADEPS=$(ASRCS:%.s=%.d)
+
+DEP=$(OBJDIR)/$(notdir $(@:%.o=%.d))
+LST=$(OBJDIR)/$(notdir $(@:%.o=%.lst))
+OBJ=$(OBJDIR)/$(notdir $@)
+MAP=$(OBJDIR)/$(TARGET).map
+
+# Build all
+all: mkdir $(COBJS) $(AOBJS) $(TARGET).elf $(TARGET).hex $(TARGET).bin
+
+# Create output folder
+mkdir:
+	$(shell if [ ! -e $(OBJDIR) ];then mkdir -p $(OBJDIR); fi)
+
+# Compile C sources
+%.o:%.c
+	@echo "    CC      $(notdir $<)"
+	@$(CC) -c $(CPU) $(CDEFS) $(INCS) $(CFLAGS) $(DFLAGS) -MMD -MP -MF "$(DEP)" -Wa,-a,-ad,-alms="$(LST)" "$<" -o "$(OBJ)"
+
+# Assemble ASM sources
+%.o:%.s
+	@echo "    AS      $(notdir $<)"
+	@$(AS) -c $(CPU) $(INCS) $(AFLAGS) $(DFLAGS) "$<" -o "$(OBJ)"
+
+# Link ELF target file and print size
+$(TARGET).elf:$(COBJS) $(AOBJS)
+	@echo "    LD [P]  $(notdir $@)"
+	@$(LD) $(OBJDIR)/*.o $(CPU) $(LFLAGS) $(DFLAGS) -T $(LDSCRIPT) -Wl,-Map=$(MAP) $(LIBS) -o $(OBJ)
+	@$(SZ) $(OBJ)
+
+# Create hex/bin programming files
+$(TARGET).hex:$(TARGET).elf
+	@echo "    HEX     $(notdir $@)"
+	@$(HEX) "$(OBJDIR)/$<" "$(OBJDIR)/$@"
+
+$(TARGET).bin:$(TARGET).elf
+	@echo "    BIN     $(notdir $@)"
+	@$(BIN) "$(OBJDIR)/$<" "$(OBJDIR)/$@"
+
+# Clean up
+clean:
+	-rm -rf $(OBJDIR)
+
+# Dependencies
+-include $(wildcard $(OBJDIR)/*.d)
+# End Build ###################################################################
+
+# End Of File #################################################################
+
+# Copyright (C) Evo-Devo Instrum. All rights reserved #########################
+

--- a/Project/GCCMF-STM32F303VCT6/rmp_platform.h
+++ b/Project/GCCMF-STM32F303VCT6/rmp_platform.h
@@ -1,0 +1,15 @@
+/******************************************************************************
+Filename    : rmp_platform.h
+Author      : pry
+Date        : 22/07/2017
+Licence     : LGPL v3+; see COPYING for details.
+Description : The platform specific types for RMP.
+******************************************************************************/
+
+/* Platform Include **********************************************************/
+#include "Platform/A7M/rmp_platform_a7m.h"
+/* End Platform Include ******************************************************/
+
+/* End Of File ***************************************************************/
+
+/* Copyright (C) Evo-Devo Instrum. All rights reserved ***********************/

--- a/Project/GCCMF-STM32F303VCT6/rmp_platform_a7m_conf.h
+++ b/Project/GCCMF-STM32F303VCT6/rmp_platform_a7m_conf.h
@@ -1,0 +1,15 @@
+/******************************************************************************
+Filename    : rmp_platform_a7m_conf.h
+Author      : zzx
+Date        : 30/03/2025
+Licence     : LGPL v3+; see COPYING for details.
+Description : The configuration file for Cortex-M HAL.
+******************************************************************************/
+
+/* Config Include ************************************************************/
+#include "Platform/A7M/Chip/STM32F303VC/rmp_platform_stm32f303vc.h"
+/* End Config Include ********************************************************/
+
+/* End Of File ***************************************************************/
+
+/* Copyright (C) Evo-Devo Instrum. All rights reserved ***********************/

--- a/Project/GCCMF-STM32F303VCT6/rmp_platform_stm32f303vc.ld
+++ b/Project/GCCMF-STM32F303VCT6/rmp_platform_stm32f303vc.ld
@@ -1,0 +1,102 @@
+/* GNU linker script for STM32F303 */
+
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 256k   /* entire flash, 256 KiB */
+    CCM (xrw)       : ORIGIN = 0x10000000, LENGTH = 8k     /* 8 KiB */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 40k    /* 40 KiB */
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+__stack_size = 4k;
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } >FLASH
+
+    .text :
+    {
+        . = ALIGN(8);
+        *(.text)
+        *(.text*)
+        *(.rodata)
+        *(.rodata*)
+        *(.glue_7)         /* glue arm to thumb code */
+        *(.glue_7t)        /* glue thumb to arm code */
+        *(.eh_frame)
+        KEEP(*(.init))
+        KEEP(*(.fini))
+        . = ALIGN(8);
+        _etext = .;
+        . = ALIGN(8);
+        PROVIDE(_sidata = .);
+    } >FLASH
+
+    .preinit_array     :
+    {
+        . = ALIGN(8);
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP (*(.preinit_array*))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+    } >FLASH
+    .init_array :
+    {
+        . = ALIGN(8);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array*))
+        PROVIDE_HIDDEN (__init_array_end = .);
+    } >FLASH
+    .fini_array :
+    {
+        . = ALIGN(8);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP (*(SORT(.fini_array.*)))
+        KEEP (*(.fini_array*))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+    } >FLASH
+
+    .data :
+    {
+        . = ALIGN(4);
+        PROVIDE(_sdata = .);
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        PROVIDE(_edata = .);
+    } >RAM AT>FLASH
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        PROVIDE(_sbss = .);
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+        PROVIDE(_ebss = .);
+    } >RAM
+
+    .stack :
+    {
+        . = ALIGN(8);
+        PROVIDE( _heap_end = . );
+        . = ALIGN(4);
+        PROVIDE(_susrstack = . );
+        . = . + __stack_size;
+        PROVIDE( _eusrstack = .);
+        PROVIDE( __initial_stack$ = .);
+        PROVIDE( _RMP_Stack = .);
+        PROVIDE( _estack = .);
+    } >RAM
+
+}

--- a/Project/GCCMF-STM32F303VCT6/rmp_test.h
+++ b/Project/GCCMF-STM32F303VCT6/rmp_test.h
@@ -1,0 +1,15 @@
+/******************************************************************************
+Filename    : rmp_test.h
+Author      : zzx
+Date        : 30/03/2025
+Licence     : LGPL v3+; see COPYING for details.
+Description : The configuration file for testing program.
+******************************************************************************/
+
+/* Config Include ************************************************************/
+#include "Test/Chip/rmp_test_stm32f303vc.h"
+/* End Config Include ********************************************************/
+
+/* End Of File ***************************************************************/
+
+/* Copyright (C) Evo-Devo Instrum. All rights reserved ***********************/


### PR DESCRIPTION
This was tested on stm32f3-discovery board, the default USART port is GPIOC UASRT1.
<img width="665" alt="Screenshot 2025-03-30 at 7 37 16 PM" src="https://github.com/user-attachments/assets/b3dac7ae-afff-431b-a3b6-7dfdb7276ca3" />
Any comments and suggestions are welcome. Besides, not sure about the `rmp_test_stm32f405rg.h` test bench